### PR TITLE
Potential fix for code scanning alert no. 1: Insecure randomness

### DIFF
--- a/nextjs/src/app/cache-demo/page.tsx
+++ b/nextjs/src/app/cache-demo/page.tsx
@@ -1,4 +1,5 @@
 import { unstable_cache } from '@/helpers/asyncCache'
+import { randomUUID } from 'crypto'
 
 // import { unstable_cache as cache } from "next/cache";
 
@@ -21,7 +22,7 @@ const getPokemonList = async (): Promise<PokenInternalInterface> => {
 
   return {
     data: data.results,
-    uuid: Math.random().toString(36).substring(7, 14),
+    uuid: randomUUID(),
   }
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/weerachai06/programming-bible/security/code-scanning/1](https://github.com/weerachai06/programming-bible/security/code-scanning/1)

In general, to fix insecure randomness in Node/Next.js, replace `Math.random()` (or any other non‑CSPRNG) with a cryptographically secure PRNG such as `crypto.randomBytes` or `crypto.randomUUID`. Avoid writing your own generator; instead, use the standard `crypto` module exposed in Node, which is available in Next.js server code.

For this specific case, the simplest and most robust fix that preserves existing behavior (a random string used as a “uuid”) is to use `crypto.randomUUID()` from Node’s `crypto` module. This returns a standard RFC 4122 UUID string, which is much more random and unguessable than the current 7‑character base‑36 fragment. It changes the format somewhat, but does not break any behavior shown in the snippet (it is only displayed). If preserving a short, random-looking string is important, we can instead generate random bytes (`crypto.randomBytes`) and encode them in base64 or hex, but using `randomUUID` is idiomatic and requires minimal code.

Concretely, in `nextjs/src/app/cache-demo/page.tsx`:

- Add an import for `randomUUID` from Node’s `crypto` module at the top.
- Replace `Math.random().toString(36).substring(7, 14)` with `randomUUID()`.

No other logic needs to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
