### PR TITLE
Potential fix for code scanning alert no. 235: Missing origin verification in `postMessage` handler

### DIFF
--- a/rust/my-rust-node/wasi-worker-browser.mjs
+++ b/rust/my-rust-node/wasi-worker-browser.mjs
@@ -28,5 +28,10 @@ const handler = new MessageHandler({
 })
 
 globalThis.onmessage = function (e) {
-  handler.handle(e)
+  const origin = typeof e.origin === 'string' ? e.origin : ''
+  const trustedOrigins = ['https://www.example.com']
+
+  if (trustedOrigins.includes(origin)) {
+    handler.handle(e)
+  }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/weerachai06/programming-bible/security/code-scanning/235](https://github.com/weerachai06/programming-bible/security/code-scanning/235)

In general, to fix missing origin verification in a `postMessage`-style handler, you inspect the incoming event’s `origin` (and optionally `source`) and only process messages from explicitly trusted origins. Events from any other origin should be ignored or handled as errors before invoking application logic.

For this specific code, the best fix with minimal behavioral change is:

- Wrap the call to `handler.handle(e)` in an `if` block that checks `e.origin` against an allowlist of trusted origins.
- If the environment may not always provide `origin` (for instance, in some worker contexts), still perform a defensive check, but keep the logic simple and conservative: only call `handler.handle` when the origin matches one of the trusted values.
- Keep all existing behavior for trusted origins unchanged; untrusted origins will now be ignored.

Concretely:

- In `rust/my-rust-node/wasi-worker-browser.mjs`, around lines 30–32, replace the bare `globalThis.onmessage` assignment with a function that:
  - Extracts `origin` from the event, defaulting to an empty string if absent.
  - Compares it against an array of allowed origins (you may want to adjust the list to your deployment environment later, but we cannot infer that here).
  - Only calls `handler.handle(e)` when the origin is trusted.

No new imports or external libraries are required; the fix uses only built-in event properties and simple JavaScript logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
